### PR TITLE
Allow travis to run on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ install:
     - sudo apt update
     - sudo apt install binutils-arm-none-eabi wine
     # These files are only accessible from Travis CI IP Addresses to prevent piracy.
-    - wget https://private.martmists.com/mwccarm.zip
-    - wget https://private.martmists.com/baserom.nds
+    - wget http://private.martmists.com/mwccarm.zip
+    - wget http://private.martmists.com/baserom.nds
     - unzip mwccarm.zip
     - mv mwccarm tools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: c
 install:
     - sudo apt update
     - sudo apt install binutils-arm-none-eabi wine
-    - wget $TOOLS_URL
+    # These files are only accessible from Travis CI IP Addresses to prevent piracy.
+    - wget https://private.martmists.com/mwccarm.zip
+    - wget https://private.martmists.com/baserom.nds
     - unzip mwccarm.zip
     - mv mwccarm tools
-    - wget $ROM_URL
-    - mv "baserom.nds?dl=1" baserom.nds
 
 script:
     - export LM_LICENSE_FILE="$(pwd)/tools/mwccarm/license.dat"


### PR DESCRIPTION
This is achieved by making the URLs public, but only accessible to Travis CI owned IP Addresses.